### PR TITLE
not checking attributes

### DIFF
--- a/tests/testthat/test-loadstartledata.R
+++ b/tests/testthat/test-loadstartledata.R
@@ -12,7 +12,7 @@ test_that("Testing correction true", {
 
   df_withcorrection <- loadStartleData(correction = TRUE)
 
-  expect_equal(df_withcorrection, readRDS("results2.rds"))
+  expect_equal(df_withcorrection, readRDS("results2.rds"), check.attributes = FALSE)
 
 })
 
@@ -21,7 +21,7 @@ test_that("Testing correction true addtail and addhead", {
 
   df_wcor_tailhead <- loadStartleData(correction = TRUE, addtail = 0.5, addhead = 0.5)
 
-  expect_equal(df_wcor_tailhead, readRDS("results3.rds"))
+  expect_equal(df_wcor_tailhead, readRDS("results3.rds"), check.attributes = FALSE)
 
 })
 
@@ -36,7 +36,7 @@ test_that("Auto import false", {
 
   df_no_auto_import <- loadStartleData(auto_import=FALSE, data = data, mass = mass)
 
-  expect_equal(df_no_auto_import, readRDS("results4.rds"))
+  expect_equal(df_no_auto_import, readRDS("results4.rds"), check.attributes = FALSE)
 
 
 })


### PR DESCRIPTION
dplyr 1.0.6, which we are about to release (https://github.com/tidyverse/dplyr/issues/5810) does a better job of keeping attributes around. Unfortunately that means that some attributes that used to be automatically removed before are now kept, and this breaks a few tests here. 

I'm not sure this is the right fix, you might want to check the attributes and either remove them, or adapt the tests, but at least this would work against both cran version of `dplyr` and the upcoming 1.0.6. 